### PR TITLE
Harden cc_riscv32 against malformed input

### DIFF
--- a/cc_riscv32.M1
+++ b/cc_riscv32.M1
@@ -200,11 +200,17 @@
     ; Reads chars until LF is read and returns LF
 :purge_macro
     rd_ra $fgetc jal                  ; read next char
+    rd_t0 !-4 addi                    ; Check for EOF
+    rs1_a0 rs2_t0 @purge_macro_eof beq ; Done if EOF
     rd_t0 !10 addi                    ; Check for '\n'
     rs1_a0 rs2_t0 @purge_macro bne    ; Keep going
 
     rd_s4 rs1_a0 mv                   ; Set C
     $reset jal                        ; Try again
+
+:purge_macro_eof
+    rd_s4 rs1_a0 mv                   ; Return EOF instead of the leading #
+    $get_token_abort jal
 
 :get_token_alpha
     rd_a0 rs1_s4 mv                   ; Send C
@@ -261,11 +267,15 @@
     rd_s4 rs1_a0 mv                   ; Set C
 :get_token_comment_block_outer
     rd_a0 rs1_s4 mv                   ; Using C
+    rd_t0 !-4 addi                    ; Check for EOF
+    rs1_a0 rs2_t0 @get_token_abort beq ; Stop if the comment was not closed
     rd_t0 !47 addi                    ; IF '/' != C
     rs1_a0 rs2_t0 @get_token_comment_block_done beq ; Done
 
 :get_token_comment_block_inner
     rd_a0 rs1_s4 mv                   ; Using C
+    rd_t0 !-4 addi                    ; Check for EOF
+    rs1_a0 rs2_t0 @get_token_abort beq ; Stop if the comment was not closed
     rd_t0 !42 addi                    ; If '*' != C
     rs1_a0 rs2_t0 @get_token_comment_block_iter beq ; jump over
 
@@ -443,11 +453,14 @@
 
 :consume_word_iter
     rd_ra $consume_byte jal           ; read next char
+    rd_t0 !-4 addi                    ; Check for EOF
+    rs1_a0 rs2_t0 @consume_word_done beq ; Stop if the string was not closed
 
     rs2_a2 @consume_word_loop bnez    ; keep looping if ESCAPE
 
     rs1_a0 rs2_a1 @consume_word_loop bnez ; keep going if C != FREQ
 
+:consume_word_done
     rd_ra $fgetc jal                  ; return next char
 
     rd_ra rs1_sp lw                   ; restore ra
@@ -1279,6 +1292,7 @@ Expected ;
     rd_ra $require_match jal          ; Require match and skip
 
 :enumerator
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a0 rs1_s4 !8 lw               ; global_token->S
     rd_a1 mv                          ; NULL
     rd_a2 rs1_s5 mv                   ; global_constant_list
@@ -1293,9 +1307,11 @@ Expected ;
     rd_a1 rs1_a1 !equal addi
     rd_ra $require_match jal          ; Require match and skip
 
+    rd_ra $require_global_token jal    ; Ensure enum value exists
     rs1_s5 rs2_s4 @16 sw              ; global_constant_list->arguments = global_token->next
 
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rs1_s4 @enum_end beqz             ; Let enum_end report missing }
 
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~comma auipc                ; ","
@@ -1305,6 +1321,7 @@ Expected ;
 
     ; Skip comma
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rs1_s4 @enum_end beqz             ; Let enum_end report missing }
 
     ; Check if there are more enumerators or if it was a trailing comma
     rd_a1 rs1_s4 !8 lw                ; global_token->S
@@ -1331,6 +1348,7 @@ Expected ;
 :program_else
     rd_ra $type_name jal              ; Figure out the type_size
     rs1_a0 @new_type beqz             ; new type if NULL == type_size
+    rd_ra $require_global_token jal    ; Missing declarator
 
     ; Add to global symbol table
     rd_a1 rs1_a0 mv                   ; put type_size in the right spot
@@ -1339,6 +1357,7 @@ Expected ;
     rd_ra $sym_declare jal            ; Declare symbol
     rd_s6 rs1_a0 mv                   ; global_symbol_list = sym_declare(global_token->s, type_size, global_symbol_list);
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rs1_s4 @program_error beqz        ; Missing ; or function body
 
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~semicolon auipc            ; ";"
@@ -1462,6 +1481,7 @@ Expected ;
     rs1_sp rs2_a1 @4 sw               ; protect a1
     rs1_sp rs2_a2 @8 sw               ; protect a2
 
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~struct auipc               ; Using "struct"
     rd_a0 rs1_a0 !struct addi
@@ -1515,6 +1535,7 @@ Expected ;
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
 
 :type_name_iter
+    rs1_s4 @type_name_done beqz        ; EOF means no more pointer markers
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_a0 rs1_a0 lbu                  ; global_token->S[0]
     rd_t0 !42 addi                    ; '*'
@@ -1621,6 +1642,7 @@ Expected ;
     rd_a5 mv                          ; LAST = NULL
 
 :create_struct_iter
+    rd_ra $require_global_token jal    ; Ensure struct member or } exists
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_a0 rs1_a0 lbu                  ; global_token->S[0]
     rd_t0 !125 addi                   ; "}"
@@ -1737,17 +1759,20 @@ Expected ;
 
     rd_ra $type_name jal              ; Get member_type
     rd_a2 rs1_a0 mv                   ; Put in place
+    rd_ra $require_global_token jal    ; Ensure member name exists
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rs1_a3 rs2_a1 @24 sw              ; I->NAME = global_token->S
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rs1_s4 @build_member_non_array beqz ; Missing ; will be reported by caller
 
     ; Check if we have an array
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~open_bracket auipc         ; Using "["
     rd_a0 rs1_a0 !open_bracket addi
     rd_ra $match jal                  ; If global_token->S == "["
-    rs1_a0 $build_member_array beqz   ; Then we have to deal with arrays in our struct
+    rs1_a0 @build_member_array beqz   ; Then we have to deal with arrays in our struct
 
+:build_member_non_array
     ; Deal with non-array case
     rd_a0 rs1_a2 !4 lw                ; member_type->SIZE
     rs1_a3 rs2_a0 @4 sw               ; I->SIZE = member_type->SIZE
@@ -1755,12 +1780,20 @@ Expected ;
 
 :build_member_array
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rd_ra $require_global_token jal    ; Require an array size after [
+    rd_a0 rs1_s4 !8 lw                ; global_token->S
+    rd_a0 rs1_a0 lbu                  ; global_token->S[0]
+    rd_t0 !48 addi                    ; '0'
+    rs1_a0 rs2_t0 @build_member_array_bad_size blt
+    rd_t0 !57 addi                    ; '9'
+    rs1_t0 rs2_a0 @build_member_array_bad_size blt
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_ra $numerate_string jal        ; convert number
     rd_a1 rs1_a2 !20 lw               ; member_type->TYPE
     rd_a1 rs1_a1 !4 lw                ; member_type->TYPE->SIZE
     rd_a0 rs1_a0 rs2_a1 mul           ; member_type->type->size * numerate_string(global_token->s)
     ; mul and div can be simulated with RV32I set if necessary. See implementation in armv7l.
+    rs1_a3 rs2_a0 @4 sw               ; I->SIZE = array size in bytes
 
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
 
@@ -1769,6 +1802,11 @@ Expected ;
     rd_a1 ~close_bracket auipc        ; Using "]"
     rd_a1 rs1_a1 !close_bracket addi
     rd_ra $require_match jal          ; Make sure we have it
+
+    $build_member_done jal
+
+:build_member_array_bad_size
+    $Fail jal                         ; Abort on a non-numeric array size
 
 :build_member_done
     rd_a4 rs1_a3 !4 lw                ; MEMBER_SIZE = I->SIZE
@@ -1793,6 +1831,7 @@ Expected ;
     rs1_sp rs2_a1 @4 sw               ; protect a1
     rs1_sp rs2_a2 @8 sw               ; protect a2
 
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a2 rs1_a0 mv                   ; put the message somewhere safe
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_ra $match jal                  ; IF required == global_token->S
@@ -1810,6 +1849,15 @@ Expected ;
     rd_a1 rs1_sp !4 lw                ; restore a1
     rd_a2 rs1_sp !8 lw                ; restore a2
     rd_sp rs1_sp !12 addi             ; deallocate stack
+    ret
+
+
+; require_global_token function
+; Aborts if global_token is NULL before callers dereference it
+:require_global_token
+    rs1_s4 @require_global_token_done bnez ; Continue if global_token is present
+    $Fail jal                         ; Abort on EOF
+:require_global_token_done
     ret
 
 
@@ -1884,6 +1932,7 @@ Expected ;
     rd_s8 rs1_a0 mv                   ; global_function_list = function
 
     rd_ra $collect_arguments jal      ; collect all of the function arguments
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
 
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_a1 ~semicolon auipc            ; ";"
@@ -1948,6 +1997,7 @@ Expected ;
     rs1_sp rs2_a2 @8 sw               ; protect a2
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
 :collect_arguments_loop
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~close_paren auipc          ; ")"
     rd_a0 rs1_a0 !close_paren addi
@@ -1957,6 +2007,7 @@ Expected ;
     ; deal with the case of there are arguments
     rd_ra $type_name jal              ; Get the type
     rd_a2 rs1_a0 mv                   ; put type_size safely out of the way
+    rd_ra $require_global_token jal    ; Ensure argument token exists
 
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~close_paren auipc          ; ")"
@@ -1997,6 +2048,7 @@ Expected ;
     rs1_s11 rs2_a2 @16 sw             ; function->args = a
 
 :collect_arguments_common
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~comma auipc                ; ","
     rd_a0 rs1_a0 !comma addi
@@ -2026,6 +2078,7 @@ Expected ;
     rs1_sp rs2_a1 @4 sw               ; protect a1
     rs1_sp rs2_a2 @8 sw               ; protect a2
 
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~open_curly_brace auipc     ; "{"
     rd_a0 rs1_a0 !open_curly_brace addi
@@ -2133,6 +2186,7 @@ Expected ;
     rd_ra $emit_out jal               ; emit it
 
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rd_ra $require_global_token jal    ; Require a label after goto
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_ra $emit_out jal               ; emit it
 
@@ -2221,6 +2275,7 @@ Expected ;
     rd_a2 rs1_s11 !4 lw               ; frame = function->locals
 
 :recursive_statement_loop
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~close_curly_brace auipc    ; "}"
     rd_a0 rs1_a0 !close_curly_brace addi
@@ -2273,9 +2328,11 @@ Expected ;
     rs1_sp rs2_a1 @4 sw               ; protect a1
     rs1_sp rs2_a2 @8 sw               ; protect a2
 
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_ra $type_name jal              ; Get the local's type
 
     rd_a1 rs1_a0 mv                   ; Put struct type* type_size in the right place
+    rd_ra $require_global_token jal    ; Missing local name
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_a2 rs1_s11 !4 lw               ; function->locals
     rd_ra $sym_declare jal            ; Declare it
@@ -2343,6 +2400,7 @@ Expected ;
     rd_ra $emit_out jal               ; emit it
 
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rs1_s4 @collect_local_done beqz   ; Missing ; will be reported below
 
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~equal auipc                ; Using "="
@@ -2450,6 +2508,9 @@ Expected ;
     rd_a1 rs1_a2 mv                   ; Passing NUMBER_STRING
     rd_ra $uniqueID_out jal           ; uniqueID_out(function->s, number_string)
 
+    rs1_s4 @process_if_has_token bnez ; EOF means no else to process
+    $process_if_done jal
+:process_if_has_token
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~else_string auipc          ; Using "else"
     rd_a0 rs1_a0 !else_string addi
@@ -2669,6 +2730,7 @@ Expected ;
     rs1_sp rs2_a1 @4 sw               ; protect a1
     rs1_sp rs2_a2 @8 sw               ; protect a2
 
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_ra $save_break_frame jal       ; Save the frame
     rd_a0 rs1_s10 mv                  ; Get current_count
     rd_s10 rs1_s10 !1 addi            ; current_count = current_count + 1
@@ -2696,6 +2758,7 @@ Expected ;
     rd_a1 rs1_a1 !open_paren addi
     rd_ra $require_match jal          ; Make sure we have it
 
+    rd_ra $require_global_token jal    ; Ensure for body is not EOF
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~semicolon auipc            ; Using ";"
     rd_a0 rs1_a0 !semicolon addi
@@ -2820,6 +2883,7 @@ Expected ;
     rd_ra $require_match jal          ; Make sure we have it
 
 :process_asm_iter
+    rs1_s4 @process_asm_done beqz      ; Missing ) will be reported below
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_a0 rs1_a0 lbu                  ; global_token->S[0]
     rd_t0 !34 addi                    ; IF global_token->S[0] == '"'
@@ -2867,6 +2931,7 @@ Expected ;
     rs1_sp rs2_a2 @8 sw               ; protect a2
 
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rs1_s4 @return_result_cleanup beqz ; Missing ; will be reported below
 
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_a0 rs1_a0 lbu                  ; global_token->S[0]
@@ -2876,6 +2941,7 @@ Expected ;
     rd_ra $expression jal             ; get the expression we are returning
 
 :return_result_cleanup
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a0 ~return_result_string_0 auipc ; Using "ERROR in return_result\nMISSING ;\n"
     rd_a0 rs1_a0 !return_result_string_0 addi
     rd_a1 ~semicolon auipc            ; Using ";"
@@ -3000,8 +3066,10 @@ Expected ;
     rs1_sp rs2_a1 @4 sw               ; protect a1
     rs1_sp rs2_a2 @8 sw               ; protect a2
 
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_ra $bitwise_expr jal           ; Collect bitwise expressions
 
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~equal auipc                ; "="
     rd_a0 rs1_a0 !equal addi
@@ -3370,6 +3438,7 @@ Expected ;
     rs1_sp rs2_ra sw                  ; protect ra
     rs1_sp rs2_a1 @4 sw               ; protect a1
 
+    rs1_s4 @postfix_expr_stub_done beqz ; EOF means no postfix operator
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~open_bracket auipc         ; Using "["
     rd_a0 rs1_a0 !open_bracket addi
@@ -3511,6 +3580,7 @@ Expected ;
     rd_a1 rs1_a1 !close_bracket addi
     rd_ra $require_match jal          ; Make sure we have it
 
+    rs1_s4 @postfix_expr_array_done beqz ; EOF means not an assignment
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~equal auipc                ; Using "="
     rd_a0 rs1_a0 !equal addi
@@ -3583,10 +3653,14 @@ Expected ;
     rd_ra $emit_out jal               ; Emit it
 
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rd_ra $require_global_token jal    ; Abort on missing member name
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~current_target auipc       ; Using current_target
     rd_a0 rs1_a0 !current_target addi
     rd_a0 rs1_a0 lw                   ; current_target
+    rs1_a0 @postfix_expr_arrow_has_target bnez ; Require a struct pointer target
+    $Fail jal
+:postfix_expr_arrow_has_target
     rd_ra $lookup_member jal          ; lookup_member(current_target, global_token->s)
     rd_a1 rs1_a0 mv                   ; struct type* I = lookup_member(current_target, global_token->s)
 
@@ -3596,6 +3670,7 @@ Expected ;
     rs1_t0 rs2_a0 sw                  ; current_target = I->TYPE
 
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rs1_s4 @postfix_expr_arrow_done beqz ; EOF means not an assignment
 
     rd_a0 rs1_a1 !8 lw                ; I->OFFSET
     rs1_a0 @postfix_expr_arrow_first beqz ; IF 0 != I->OFFSET then we don't need to do an offset
@@ -3619,6 +3694,7 @@ Expected ;
     rs1_a0 rs2_t0 @postfix_expr_arrow_done blt ; Check IF I->SIZE >= 4, otherwise be done
 
     ; Last chance for load
+    rs1_s4 @postfix_expr_arrow_done beqz ; EOF means not an assignment
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~equal auipc                ; Using "="
     rd_a0 rs1_a0 !equal addi
@@ -3645,6 +3721,7 @@ Expected ;
     rs1_sp rs2_ra sw                  ; protect ra
     rs1_sp rs2_a1 @4 sw               ; protect a1
 
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~sizeof_string auipc        ; Using postfix_expr
     rd_a0 rs1_a0 !sizeof_string addi
@@ -3904,6 +3981,7 @@ Expected ;
     rd_a1 rs1_a1 !open_paren addi
     rd_ra $require_match jal          ; Make sure we have it
 
+    rd_ra $require_global_token jal    ; Ensure argument list is present
     rd_a0 ~function_call_string_1 auipc ; Using "rd_sp rs1_sp !-12 addi\nrs1_sp rs2_ra @4 sw\t# Protect the old return pointer\n"
     rd_a0 rs1_a0 !function_call_string_1 addi
     rd_ra $emit_out jal               ; Emit it
@@ -3937,12 +4015,14 @@ Expected ;
     rd_a4 !1 addi                     ; PASSED = 1
 
 :function_call_gen_iter
+    rd_ra $require_global_token jal    ; Ensure global_token is not EOF
     rd_a0 rs1_s4 !8 lw                ; global_token->S
     rd_a0 rs1_a0 lbu                  ; global_token->S[0]
     rd_t0 !44 addi                    ; ","
     rs1_a0 rs2_t0 @function_call_gen_done bne ; Check IF global_token->S[0] == ","
 
     rd_s4 rs1_s4 lw                   ; global_token = global_token->next
+    rd_ra $require_global_token jal    ; Ensure argument follows comma
 
     rd_ra $expression jal             ; Collect the argument
 
@@ -4051,6 +4131,7 @@ Expected ;
 
     rd_a2 rs1_a0 mv                   ; Protect A
 
+    rs1_s4 @variable_load_regular beqz ; EOF means not a function call
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~open_paren auipc           ; "("
     rd_a0 rs1_a0 !open_paren addi
@@ -4091,6 +4172,7 @@ Expected ;
     rd_ra $emit_out jal               ; Emit it
 
     ; Check for special case of assignment
+    rs1_s4 @variable_load_done beqz    ; EOF means not an assignment
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~equal auipc                ; Using "="
     rd_a0 rs1_a0 !equal addi
@@ -4122,6 +4204,7 @@ Expected ;
 
     rd_a0 rs1_a0 !8 lw                ; A->S
     rd_a2 rs1_a0 mv                   ; Protect A->S
+    rs1_s4 @function_load_regular beqz ; EOF means address load
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~open_paren auipc           ; Using "("
     rd_a0 rs1_a0 !open_paren addi
@@ -4196,6 +4279,7 @@ Expected ;
     rd_a0 rs1_a0 !global_load_string_2 addi
     rd_ra $emit_out jal               ; Emit it
 
+    rs1_s4 @global_load_done beqz      ; EOF means not an assignment
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_a0 ~equal auipc ; "="
     rd_a0 rs1_a0 !equal addi
@@ -4506,6 +4590,7 @@ Expected ;
     rd_a0 rs1_a2 mv                   ; Put name in the right place
     rd_a2 rs1_a1 mv                   ; Protect S
 
+    rs1_s4 @general_recursion_done beqz ; EOF means no matching operator
     rd_a1 rs1_s4 !8 lw                ; global_token->S
     rd_ra $match jal                  ; IF match(name, global_token->s)
     rs1_a0 @general_recursion_done bnez ; do recursion, else skip it

--- a/test/cc_riscv32-fuzz.sh
+++ b/test/cc_riscv32-fuzz.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -eu
+
+tmp=${TMPDIR:-/tmp}/cc_riscv32-fuzz.$$
+mkdir -p "$tmp"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+M1=${M1:-M1}
+HEX2=${HEX2:-hex2}
+QEMU=${QEMU:-qemu-riscv32}
+
+if ! command -v "$QEMU" >/dev/null 2>&1; then
+	echo "skipping: $QEMU not found"
+	exit 0
+fi
+
+"$M1" --little-endian --architecture riscv32 \
+	-f riscv32_defs.M1 \
+	-f cc_riscv32.M1 \
+	-o "$tmp/cc_riscv32.hex2"
+"$HEX2" --little-endian --architecture riscv32 \
+	--base-address 0x10000 \
+	-f ELF-riscv32.hex2 \
+	-f "$tmp/cc_riscv32.hex2" \
+	-o "$tmp/cc_riscv32"
+chmod +x "$tmp/cc_riscv32"
+
+check_no_crash()
+{
+	name=$1
+	input=$2
+	printf '%s' "$input" > "$tmp/$name.c"
+	set +e
+	timeout 2 "$QEMU" "$tmp/cc_riscv32" "$tmp/$name.c" "$tmp/$name.M1" >/dev/null 2>&1
+	status=$?
+	set -e
+	if [ "$status" -eq 124 ]; then
+		echo "$name timed out"
+		exit 1
+	fi
+	if [ "$status" -ge 128 ]; then
+		echo "$name crashed with status $status"
+		exit 1
+	fi
+}
+
+check_no_crash unterminated-string '"'
+check_no_crash line-comment-eof 'int#main() { return 0; }'
+check_no_crash block-comment-eof '/*'
+check_no_crash global-declarator-eof 'int 0'
+check_no_crash global-open-paren-eof 'int('
+check_no_crash global-close-brace-eof 'int}'
+check_no_crash global-quote-eof 'int"'
+check_no_crash global-single-quote-eof "int'"
+check_no_crash function-arguments-eof 'int 0('
+check_no_crash function-declaration-eof 'int 0()'
+check_no_crash function-expression-eof 'int 0()0'
+check_no_crash function-return-eof 'int 0()return'
+check_no_crash function-body-eof 'int 0(){'
+check_no_crash function-body-statement-eof 'int 0(){0;'
+check_no_crash function-if-eof 'int 0()if(0)'
+check_no_crash function-return-unary-eof 'int 0()return~'
+check_no_crash function-local-name-eof 'int 0()int'
+check_no_crash function-global-load-eof 'int x;int 0()x'
+check_no_crash function-name-load-eof 'int n()n'
+check_no_crash function-local-delimiter-eof 'int 0(){0;int}'
+check_no_crash function-local-declaration-eof 'int 0()int 0'
+check_no_crash function-if-no-else-eof 'int 0()if(0)0;'
+check_no_crash function-array-target-eof 'int 0()0[0'
+check_no_crash function-call-open-eof 'int m0in()return m0in('
+check_no_crash function-local-load-eof 'int 0(){int i;i'
+check_no_crash enum-open-eof 'enum {'
+check_no_crash enum-value-eof 'enum { A ='
+check_no_crash enum-comma-eof 'enum { A = 1,'
+check_no_crash asm-open-eof 'int main() asm('
+check_no_crash asm-string-eof 'int main() asm("x"'
+check_no_crash for-open-eof 'int main() for('
+check_no_crash sizeof-open-eof 'int main() return sizeof('
+check_no_crash struct-open-eof 'struct s {'
+check_no_crash struct-member-type-eof 'struct s { int'
+check_no_crash struct-array-open-eof 'struct s { int x['
+check_no_crash arrow-member-eof 'struct s { int x; }; int main(){ struct s *p; p->'
+check_no_crash arrow-load-eof 'struct s { int x; }; int main(){ struct s *p; p->x'
+check_no_crash goto-label-eof 'int main() goto'
+check_no_crash scalar-array-index-eof 'int n(){int x;x[0]'
+check_no_crash struct-array-load-eof 'struct S{char*s;int y[4];};int n(){struct S*p;p->s="";return p->y[0]'
+check_no_crash scalar-arrow-member-eof 'int n(){int x;1->y'
+check_no_crash struct-array-member-type-eof 'struct S{S e[a'


### PR DESCRIPTION
Harden the bootstrap compiler against malformed/truncated input discovered by fuzzing.
This adds EOF/null guards so invalid source fails cleanly instead of crashing.
