### PR TITLE
Exit catm with an error when an input file cannot be opened

### DIFF
--- a/GAS/catm_riscv32.S
+++ b/GAS/catm_riscv32.S
@@ -53,6 +53,7 @@ core:
     li a0, -100                       # AT_FDCWD
     li a2, 0                          # read only
     ecall                             # syscall
+    bltz a0, fail                     # Check if the open failed
     mv s3, a0                         # protect input fd
 
 keep:
@@ -61,6 +62,7 @@ keep:
     mv a1, s2                         # read into buffer
     li a2, 0x100000                   # read 1MiB
     ecall                             # syscall
+    bltz a0, fail                     # Check if the read failed
     mv s4, a0                         # actual number of bytes read
 
     li a7, 64                         # sys_write
@@ -72,6 +74,12 @@ keep:
     li a2, 0x100000                   # 1MiB
     beq s4, a2, keep                  # keep looping if buffer was full
     j core                            # otherwise move to next file
+
+fail:
+    # An input file could not be read
+    li a7, 93                         # sys_exit
+    li a0, 1                          # Return code 1
+    ecall                             # exit(1)
 
 Done:
     # Terminate program with 0 return code

--- a/catm_riscv32.hex2
+++ b/catm_riscv32.hex2
@@ -124,6 +124,8 @@ F3 00              ## e_machine Indicating RISC-V
     .00060000 13000000
     # ecall                             ; syscall
     73000000
+    # rs1_a0 @fail blt                   ; branch if the open failed
+    .00000500 @fail 63400000
     # rd_s3 rs1_a0 addi                 ; protect input fd
     .80090000 .00000500 13000000
 
@@ -138,6 +140,8 @@ F3 00              ## e_machine Indicating RISC-V
     .00060000 .00001000 37000000
     # ecall                             ; syscall
     73000000
+    # rs1_a0 @fail blt                   ; branch if the read failed
+    .00000500 @fail 63400000
     # rd_s4 rs1_a0 addi                 ; actual number of bytes read
     .000A0000 .00000500 13000000
 
@@ -158,6 +162,15 @@ F3 00              ## e_machine Indicating RISC-V
     .00000A00 .0000C000 @keep 63000000
     # $core jal                         ; otherwise move to next file
     $core 6F000000
+
+:fail
+    # An input file could not be read
+    # rd_a7 !93 addi                     ; sys_exit
+    .80080000 .0000D005 13000000
+    # rd_a0 !1 addi                      ; Return code 1
+    .00050000 .00001000 13000000
+    # ecall                              ; exit(1)
+    73000000
 
 :Done
     # Terminate program with 0 return code


### PR DESCRIPTION
`catm` never checks the result of `open()`, so a missing or unreadable input leaves the negative errno in the input fd register; `read()` then returns `-EBADF` and that value becomes the `write()` byte count, corrupting or silently truncating the output while `catm` still exits 0.

This adds a check after the input `open()` and after each `read()`, exiting 1 instead. Valid inputs still produce byte-identical output; both the GAS source and the hand-written seed encoding are updated.
